### PR TITLE
Removed MegaRBL - it has been removed from the wikipedia list and its…

### DIFF
--- a/check-dnsbl.py
+++ b/check-dnsbl.py
@@ -42,7 +42,6 @@ default_blacklists = [
     ('bl.blocklist.de',           'fail2ban reports etc.'),
     ('srnblack.surgate.net',      'feeders'),
     ('all.s5h.net',               'traps'),
-    ('rbl.megarbl.net',           'traps'),
     ('rbl.realtimeblacklist.com', 'lists ip ranges'),
     ('b.barracudacentral.org',    'traps'),
     ('virbl.dnsbl.bit.nl',        'Viruse senders')


### PR DESCRIPTION
… domain has expired. Its reporting my email server as blacklisted (its clear on all other lists) and I can't have it removed from the list because the web-site is unreachable.
